### PR TITLE
Gitignore redis snapshot binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 assets/
 node_modules/
+dump.rdb


### PR DESCRIPTION
`/dump.rdb` is [something Redis does](https://redis.io/topics/persistence#snapshotting) and I’m guessing people shouldn’t commit it to their app repos.