### PR TITLE
🛠️ fix pretty command

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "NODE_ENV=development node ./bin/www",
     "build": "NODE_ENV=production webpack --config ./config/webpack.config.js --progress --profile --colors",
     "clean": "rm -rf ./assets && mkdir ./assets",
-    "pretty": "prettier --single-quote --trailing-comma es5 --write {client,bin,config,server}/**/*.js",
+    "pretty": "prettier --single-quote --trailing-comma es5 --write {client,bin,config,server}{/*,/**/*}.js",
     "precommit": "yarn run pretty"
   },
   "engines": {


### PR DESCRIPTION
closes #21 
We just needed to do `{*/,**/*}.js` You're right that I think it *should* work with the way it was but it seems like the `prettier` cli might have a bug. Maybe we should open an issue on their repo?