### PR TITLE
🛠️ fix cant send headers error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -80,7 +80,7 @@ if (isDevelopment) {
 app.get('/', function(request, response) {
   const { session: { shop, accessToken } } = request;
   if (!accessToken) {
-    response.redirect(`/auth/shopify?shop=${request.query.shop}`);
+    return response.redirect(`/auth/shopify?shop=${request.query.shop}`);
   }
 
   persistentStore.storeUser({ accessToken, shop }, (err, userId) => {

--- a/server/routes/shopifyApiProxy.js
+++ b/server/routes/shopifyApiProxy.js
@@ -10,11 +10,11 @@ module.exports = function shopifyApiProxy(request, response, next) {
 
   return store.getToken(userId, (err, userData) => {
     if (err) {
-      return response.status(500);
+      return response.status(500).send(err);
     }
 
     if (userData == null) {
-      return response.status(401);
+      return response.status(401).send('User not found');
     }
 
     const { shop, accessToken } = userData;
@@ -26,7 +26,7 @@ module.exports = function shopifyApiProxy(request, response, next) {
     });
 
     if (!inAllowed) {
-      return response.status(403);
+      return response.status(403).send('Endpoint not in whitelist');
     }
 
     const fetchOptions = {


### PR DESCRIPTION
This pr fixes #15 
There were a few cases where we were not returning properly out of our middlewares. For the record, you always need to `return`  when you are doing a conditional redirect, or you'll try to send the same request twice. You also always need to call `.send` after setting the status with `.status` on a response object.