### PR TITLE
✨ Implement webhook middleware

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -18,8 +18,6 @@ import {
 } from './actions';
 import { connect } from 'react-redux';
 
-const userId = window.userId;
-
 class App extends React.Component {
   componentDidMount() {
     const { dispatch, searchFields } = this.props;

--- a/client/actions/index.js
+++ b/client/actions/index.js
@@ -17,9 +17,9 @@ export function updateSearchLimit(limit) {
 }
 
 export function searchAction(searchFields) {
-  const userId = window.userId;
+  const { token, shop } = window;
   const { title, limit } = searchFields;
-  let params = `limit=${limit}&userId=${userId}`;
+  let params = `limit=${limit}&token=${token}&shop=${shop}`;
   if (title.length) {
     params += `&title=${title}`;
   }

--- a/server/middleware/webhooks.js
+++ b/server/middleware/webhooks.js
@@ -1,0 +1,34 @@
+const crypto = require('crypto');
+const store = require('../persistentStore');
+
+const { SHOPIFY_APP_SECRET } = process.env;
+
+function withWebhook(request, response, next) {
+  console.log('I am webhook');
+  const { body: data } = request;
+  const hmac = request.get('X-Shopify-Hmac-Sha256');
+  const topic = request.get('X-Shopify-Topic');
+  const shopDomain = request.get('X-Shopify-Shop-Domain');
+
+  const generated_hash = crypto
+    .createHmac('sha256', SHOPIFY_APP_SECRET)
+    // probably change the parser we're using
+    .update(JSON.stringify(data))
+    .digest('base64');
+
+  if (generated_hash !== hmac) {
+    return response.status(401).send("Request doesn't pass HMAC validation");
+  }
+
+  store.getUser({ shop: shopDomain }, (error, { accessToken }) => {
+    if (error) {
+      next(error);
+    }
+
+    request.webhook = { topic, shopDomain, accessToken };
+
+    next();
+  });
+}
+
+module.exports = { withWebhook };

--- a/server/persistentStore/index.js
+++ b/server/persistentStore/index.js
@@ -3,24 +3,44 @@ const uuid = require('uuid/v1');
 
 const redis = Redis.createClient();
 
-module.exports.storeUser = ({ accessToken, shop }, done) => {
-  const id = uuid();
+function storeUser({ shop, accessToken }, done) {
+  const clientToken = uuid();
 
-  redis.hmset(id, { accessToken, shop }, err => {
+  redis.hmset(shop, { accessToken, clientToken }, err => {
     if (err) {
       return done(err);
     }
 
-    done(null, id);
+    done(null, clientToken);
   });
-};
+}
 
-module.exports.getToken = (id, done) => {
-  redis.hgetall(id, (err, remoteToken) => {
+function getUser({ shop }, done) {
+  redis.hgetall(shop, (err, { clientToken, accessToken }) => {
     if (err) {
       return done(err);
     }
 
-    done(null, remoteToken);
+    done(null, { clientToken, accessToken });
   });
+}
+
+function verifyClientToken({ shop, token }, done) {
+  redis.hgetall(shop, (err, { accessToken, clientToken }) => {
+    if (err) {
+      return done(err);
+    }
+
+    if (clientToken !== token) {
+      return done(null, false);
+    }
+
+    return done(null, true);
+  });
+}
+
+module.exports = {
+  getUser,
+  storeUser,
+  verifyClientToken,
 };

--- a/server/routes/webhooks.js
+++ b/server/routes/webhooks.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const { withWebhook } = require('../middleware/webhooks');
+const router = express.Router();
+
+router.all('/order-create', withWebhook, (request, response) => {
+  console.log('We got a webhook!');
+  console.log('Details: ', request.webhook);
+  console.log('Body:', request.body);
+});
+
+module.exports = router;

--- a/server/views/app.ejs
+++ b/server/views/app.ejs
@@ -9,8 +9,9 @@
     <script src="https://cdn.shopify.com/s/assets/external/app.js"></script>
 
     <script>
-      window.userId = "<%= userId %>"
+      window.token = "<%= token %>"
       window.apiKey = "<%= apiKey %>"
+      window.shop = "<%= shop %>"
       window.shopOrigin = "https://<%= shop %>"
     </script>
 


### PR DESCRIPTION
closes #6 
### Summary
This PR 
- adds support for webhooks using the `withWebhook` middleware.
- makes our redis store use `shopDomain` as the key (when we add the abstraction in #24  we'll want to make sure they all use this new api)
- implements an example webhook endpoint

### Pics
![image](https://user-images.githubusercontent.com/4889856/29332173-1d5dea8a-81cd-11e7-8856-4432a0525f09.png)
