### PR TITLE
set forceRedirect to false in dev env

### DIFF
--- a/server/views/app.ejs
+++ b/server/views/app.ejs
@@ -17,6 +17,11 @@
         shopOrigin: window.shopOrigin,
       }
 
+      // This will allow you to access the app outside of the Shopify
+      // parent iframe in development mode. Doing this will give you
+      // access to React and Redux dev tools, but will also disrupt
+      // postmessages to the parent and block EASDK calls
+      // https://help.shopify.com/api/sdks/shopify-apps/embedded-app-sdk/methods#shopifyapp-init-config
       if ("<%= process.env.NODE_ENV %>" === 'development') {
         shopifyAppConfig.forceRedirect = false;
       }

--- a/server/views/app.ejs
+++ b/server/views/app.ejs
@@ -11,13 +11,17 @@
     <script>
       window.apiKey = "<%= apiKey %>"
       window.shopOrigin = "https://<%= shop %>"
-    </script>
 
-    <script>
-      ShopifyApp.init({
+      const shopifyAppConfig = {
         apiKey: window.apiKey,
-        shopOrigin: window.shopOrigin
-      });
+        shopOrigin: window.shopOrigin,
+      }
+
+      if ("<%= process.env.NODE_ENV %>" === 'development') {
+        shopifyAppConfig.forceRedirect = false;
+      }
+
+      ShopifyApp.init(shopifyAppConfig);
     </script>
 
     <div id="root"></div>


### PR DESCRIPTION
While the app is embedded in an iframe, we don’t have access to react and redux dev tools in Chrome.

This change sets the EASDK’s `forceRedirect` to false when the app is run in dev mode, which lets us load the app outside of Shopify’s iframe, thus giving us access to these tools.