### PR TITLE
bump shopify-express version to 1.0.0-alpha.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "@shopify/polaris": "^1.8.3",
-    "@shopify/shopify-express": "^1.0.0-alpha.5",
+    "@shopify/shopify-express": "^1.0.0-alpha.6",
     "chalk": "^1.1.3",
     "connect-redis": "^3.3.0",
     "debug": "~2.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,15 +55,17 @@
     core-js "^2.4.1"
     react-addons-transition-group "^15.4.2"
 
-"@shopify/shopify-express@^1.0.0-alpha.5":
-  version "1.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-express/-/shopify-express-1.0.0-alpha.5.tgz#a68f559a97f4fe28361e6c4546e334b95cdfa3ba"
+"@shopify/shopify-express@^1.0.0-alpha.6":
+  version "1.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-express/-/shopify-express-1.0.0-alpha.6.tgz#071f5c1a293de7c79326e02ebb49ac1ce2750ae4"
   dependencies:
     body-parser "^1.18.2"
     connect-redis "^3.3.0"
     express "^4.16.2"
     express-session "^1.15.3"
     knex "^0.13.0"
+    node-fetch "^1.7.3"
+    raw-body "^2.3.2"
     redis "^2.7.1"
     sqlite3 "^3.1.9"
     url "^0.11.0"
@@ -3476,7 +3478,7 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-node-fetch@^1.0.1:
+node-fetch@^1.0.1, node-fetch@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
@@ -4262,7 +4264,7 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raw-body@2.3.2:
+raw-body@2.3.2, raw-body@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
   dependencies:


### PR DESCRIPTION
bumps shopify-express dependency to latest & greatest