### PR TITLE
Use `shopDomain` as `shopName`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "redux": "^3.6.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
-    "shopify-api-node": "^2.9.0",
+    "shopify-api-node": "^2.11.0",
     "sqlite3": "^3.1.9",
     "url": "^0.11.0",
     "webpack-hot-middleware": "^2.18.0",

--- a/server/index.js
+++ b/server/index.js
@@ -44,8 +44,7 @@ const shopifyConfig = {
 };
 
 const registerWebhook = function(shopDomain, accessToken, webhook) {
-  const shopName = shopDomain.replace('.myshopify.com', '');
-  const shopify = new ShopifyAPIClient({ shopName: shopName, accessToken: accessToken });
+  const shopify = new ShopifyAPIClient({ shopName: shopDomain, accessToken: accessToken });
   shopify.webhook.create(webhook).then(
     response => console.log(`webhook '${webhook.topic}' created`),
     err => console.log(`Error creating webhook '${webhook.topic}'. ${JSON.stringify(err.response.body)}`)


### PR DESCRIPTION
`shopify-api-node@>=2.11.0` allows the shop's 'myshopify.com' domain to be used as `shopName`.

Refs: https://github.com/MONEI/Shopify-api-node/commit/731696307b7aa524031eee682c69d50530c60a52