### PR TITLE
Update ES6 arrow function compiling support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,10 +2,11 @@
   "presets": [
     "react",
     "env",
-    "es2015"
+    "es2015",
+    "stage-0"
   ],
   "plugins": [
     "react-hot-loader/babel",
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
   ]
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "babel-preset-env": "^1.5.2",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.3.13",
     "css-loader": "^0.28.4",
     "eslint": "3.19.0",
     "eslint-plugin-prettier": "^2.1.2",


### PR DESCRIPTION
This can solve issue [#103](https://github.com/Shopify/shopify-node-app/issues/103)