### PR TITLE
Upgrade to Polaris 2.0

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -1,6 +1,5 @@
-import React, { Component} from 'react';
-import { Page } from '@shopify/polaris';
-import { EmbeddedApp } from '@shopify/polaris/embedded';
+import React, { Component } from 'react';
+import { Page, AppProvider } from '@shopify/polaris';
 
 import ApiConsole from './components/ApiConsole'
 
@@ -9,7 +8,7 @@ class App extends Component {
     const { apiKey, shopOrigin } = window;
 
     return (
-      <EmbeddedApp shopOrigin={shopOrigin} apiKey={apiKey}>
+      <AppProvider shopOrigin={shopOrigin} apiKey={apiKey}>
         <Page
           title="My application"
           breadcrumbs={[{ content: 'Home', url: '/foo' }]}
@@ -17,7 +16,7 @@ class App extends Component {
         >
           <ApiConsole />
         </Page>
-      </EmbeddedApp>
+      </AppProvider>
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "android >= 4.4"
   ],
   "dependencies": {
-    "@shopify/polaris": "^2.0.0",
+    "@shopify/polaris": "^2.3.1",
     "@shopify/shopify-express": "^1.0.0-alpha.7",
     "chalk": "^1.1.3",
     "connect-redis": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "android >= 4.4"
   ],
   "dependencies": {
-    "@shopify/polaris": "^1.8.3",
+    "@shopify/polaris": "^2.0.0",
     "@shopify/shopify-express": "^1.0.0-alpha.7",
     "chalk": "^1.1.3",
     "connect-redis": "^3.3.0",
@@ -37,8 +37,8 @@
     "express-session": "^1.15.3",
     "knex": "^0.13.0",
     "morgan": "~1.8.1",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.4.0",
+    "react-dom": "^16.4.0",
     "nodemon": "^1.17.1",
     "react-object-inspector": "^0.2.1",
     "react-redux": "^5.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,15 +6,7 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@shopify/images/-/images-1.1.3.tgz#b1aece3174beb101375ace13c6651b7049648b79"
 
-"@shopify/javascript-utilities@^1.1.0":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@shopify/javascript-utilities/-/javascript-utilities-1.1.6.tgz#f9272feb1f0b7a3dd63a9e490548b17055e6d9f2"
-  dependencies:
-    "@types/lodash" "^4.14.65"
-    "@types/react" "^15.0.21"
-    lodash "^4.17.4"
-
-"@shopify/javascript-utilities@^2.0.0":
+"@shopify/javascript-utilities@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@shopify/javascript-utilities/-/javascript-utilities-2.1.0.tgz#b04b2787dd66329b8261b62ebe61bdf85790d6c7"
   dependencies:
@@ -23,37 +15,36 @@
     lodash "^4.17.4"
     lodash-decorators "^4.3.5"
 
-"@shopify/polaris@^1.8.3":
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-1.8.3.tgz#f2766a96b5f721bd06a67ec014f5ce9ccf672b90"
+"@shopify/polaris@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@shopify/polaris/-/polaris-2.0.0.tgz#a40131535076a12607708360871ecae5de1b64ce"
   dependencies:
     "@shopify/images" "^1.1.0"
-    "@shopify/javascript-utilities" "^2.0.0"
-    "@shopify/react-utilities" "^1.2.0"
+    "@shopify/javascript-utilities" "^2.1.0"
+    "@shopify/react-utilities" "2.0.0-beta.9"
     "@types/prop-types" "^15.5.2"
-    "@types/react" "^16.0.10"
-    "@types/react-dom" "^16.0.1"
-    "@types/react-transition-group" "^2.0.6"
+    "@types/react" "^16.3.5"
+    "@types/react-dom" "^16.0.4"
+    "@types/react-transition-group" "^2.0.7"
     babel-runtime "^6.23.0"
-    core-js "^2.4.1"
-    hoist-non-react-statics "^2.3.1"
+    core-js "^2.5.1"
+    hoist-non-react-statics "^2.5.0"
     lodash "^4.17.4"
-    prop-types "^15.5.10"
-    react-transition-group "^2.2.1"
-    tslib "^1.7.1"
+    lodash-decorators "^4.3.5"
+    prop-types "^15.6.1"
+    react-transition-group "^2.3.0"
+    tslib "^1.8.0"
 
-"@shopify/react-utilities@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@shopify/react-utilities/-/react-utilities-1.2.0.tgz#a4caab29026d44afa55bf2e407ce6cb7f0509694"
+"@shopify/react-utilities@2.0.0-beta.9":
+  version "2.0.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@shopify/react-utilities/-/react-utilities-2.0.0-beta.9.tgz#0b1df35bb7bc0369adc955c6ea59a743bffc1ef1"
   dependencies:
-    "@shopify/javascript-utilities" "^1.1.0"
-    "@types/classnames" "^0.0.32"
-    "@types/node" "^7.0.12"
-    "@types/react" "^15.0.21"
-    "@types/react-addons-transition-group" "^0.14.19"
+    "@shopify/javascript-utilities" "^2.1.0"
+    "@types/classnames" "^2.2.3"
+    "@types/node" "^8.0.41"
+    "@types/react" "^16.0.10"
     classnames "^2.2.5"
-    core-js "^2.4.1"
-    react-addons-transition-group "^15.4.2"
+    core-js "^2.5.1"
 
 "@shopify/shopify-express@^1.0.0-alpha.7":
   version "1.0.0-alpha.7"
@@ -75,9 +66,9 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
-"@types/classnames@^0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-0.0.32.tgz#449abcd9a826807811ef101e58df9f83cfc61713"
+"@types/classnames@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.3.tgz#3f0ff6873da793870e20a260cada55982f38a9e5"
 
 "@types/lodash@^4.14.65":
   version "4.14.85"
@@ -87,30 +78,24 @@
   version "8.0.53"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.53.tgz#396b35af826fa66aad472c8cb7b8d5e277f4e6d8"
 
-"@types/node@^7.0.12":
-  version "7.0.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.48.tgz#24bfdc0aa82e8f6dbd017159c58094a2e06d0abb"
+"@types/node@^8.0.41":
+  version "8.10.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.17.tgz#d48cf10f0dc6dcf59f827f5a3fc7a4a6004318d3"
 
 "@types/prop-types@^15.5.2":
   version "15.5.2"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.2.tgz#3c6b8dceb2906cc87fe4358e809f9d20c8d59be1"
 
-"@types/react-addons-transition-group@^0.14.19":
-  version "0.14.19"
-  resolved "https://registry.yarnpkg.com/@types/react-addons-transition-group/-/react-addons-transition-group-0.14.19.tgz#74053d3b1d30644644149343323e05570ccb9fd2"
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-dom@^16.0.1":
-  version "16.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.3.tgz#8accad7eabdab4cca3e1a56f5ccb57de2da0ff64"
+"@types/react-dom@^16.0.4":
+  version "16.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.5.tgz#a757457662e3819409229e8f86795ff37b371f96"
   dependencies:
     "@types/node" "*"
     "@types/react" "*"
 
-"@types/react-transition-group@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.6.tgz#8903fa2cf540ba454461590bff811a787889617c"
+"@types/react-transition-group@^2.0.7":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.9.tgz#ed6a71fb711e524345844defec2a861c1a222a03"
   dependencies:
     "@types/react" "*"
 
@@ -118,9 +103,11 @@
   version "16.0.25"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.25.tgz#bf696b83fe480c5e0eff4335ee39ebc95884a1ed"
 
-"@types/react@^15.0.21":
-  version "15.6.7"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.6.7.tgz#e910b6aace59d8d0b48dd679c2c03cffedafeec6"
+"@types/react@^16.3.5":
+  version "16.3.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.14.tgz#f90ac6834de172e13ecca430dcb6814744225d36"
+  dependencies:
+    csstype "^2.2.0"
 
 abbrev@1:
   version "1.1.1"
@@ -1303,10 +1290,6 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chain-function@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
-
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1605,9 +1588,13 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
+
+core-js@^2.5.1:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1781,6 +1768,10 @@ csso@~2.3.1:
   dependencies:
     clap "^1.0.9"
     source-map "^0.5.3"
+
+csstype@^2.2.0:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.2.tgz#4534308476ceede8fbe148b9b99f9baf1c80fa06"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -1983,9 +1974,9 @@ doctrine@^2.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-helpers@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
+dom-helpers@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -3006,9 +2997,13 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^2.2.1, hoist-non-react-statics@^2.3.1:
+hoist-non-react-statics@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
+
+hoist-non-react-statics@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -4872,7 +4867,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -5042,19 +5037,13 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-transition-group@^15.4.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-transition-group/-/react-addons-transition-group-15.6.2.tgz#8baebc2ae91ccdbf245fe29c9fd3d36f8b471923"
-  dependencies:
-    react-transition-group "^1.2.0"
-
 react-deep-force-update@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
 
-react-dom@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
+react-dom@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.0.tgz#099f067dd5827ce36a29eaf9a6cdc7cbf6216b1e"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -5092,30 +5081,17 @@ react-redux@^5.0.5:
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
 
-react-transition-group@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
+react-transition-group@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.1.tgz#31d611b33e143a5e0f2d94c348e026a0f3b474b6"
   dependencies:
-    chain-function "^1.0.0"
-    dom-helpers "^3.2.0"
+    dom-helpers "^3.3.1"
     loose-envify "^1.3.1"
-    prop-types "^15.5.6"
-    warning "^3.0.0"
+    prop-types "^15.6.1"
 
-react-transition-group@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
-  dependencies:
-    chain-function "^1.0.0"
-    classnames "^2.2.5"
-    dom-helpers "^3.2.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.5.8"
-    warning "^3.0.0"
-
-react@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
+react@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -6142,6 +6118,10 @@ tslib@^1.7.1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.0.tgz#dc604ebad64bcbf696d613da6c954aa0e7ea1eb6"
 
+tslib@^1.8.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.1.tgz#a5d1f0532a49221c87755cfcc89ca37197242ba7"
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -6387,12 +6367,6 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  dependencies:
-    loose-envify "^1.0.0"
 
 watchpack@^1.3.1:
   version "1.4.0"


### PR DESCRIPTION
I wanted those DataTables **baaaad**.

Following directions from the [Polaris 2.0 change log](https://github.com/Shopify/polaris/blob/master/CHANGELOG.md).

This only thing I ran into is that I had to change my Apps `Whitelisted redirection URLs` from:

`https://topre_is.rubber.domes/auth/shopify/callback`
to:
`https://topre_is.rubber.domes/shopify/auth/callback` 

This threw me for a loop for a long time!

This resolves #117  

Reminder: This **is** a major version bump. There are breaking changes.
However, it made little sense for the seed app to not have the new awesome Polaris features!