### PR TITLE
add babel transform-class-properties

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
   ],
   "plugins": [
     "react-hot-loader/babel",
-    "transform-object-rest-spread"
+    "transform-object-rest-spread",
+    "transform-class-properties"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-core": "^6.25.0",
     "babel-loader": "^7.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.5.2",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",


### PR DESCRIPTION
While working from this package, our team noticed that this babel plugin to work with property initializers was missing.
This causes issues when a developer wants to use that specific feature, or copy/paste code snippets from Polaris.
This adds PR adds the package to package.json and the babellrc file.