### PR TITLE
🗒️ add notice to readme about shopify-express deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## Deprecation of `shopify-express`
+
+:exclamation: **This project is currently based on deprecated technology** (the `shopify-express` module). We will be updating it to use tools more inline with our internal node applications shortly.
+
+In the meantime if you would like a headstart learning some of our other tools, [this workshop](https://github.com/Shopify/unite-react-node-app-workshop/blob/master/workshop.md) can help you get started. You can also jump straight to the final `step7` branch to have a reasonable starting place to build an app from. Note that it is not, however, meant to be a production ready app boilerplate.
+
+If you would like to go straight to the source, many of our application libraries can be found in the [quilt](https://github.com/Shopify/quilt) repo. These are all used internally and written against technologies we use for our own applications.
+
 # Shopify Node App
 
 The goal of this example app is to provide a starting point for Shopify app developers so that they will be able to quickly

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 In the meantime if you would like a headstart learning some of our other tools, [this workshop](https://github.com/Shopify/unite-react-node-app-workshop/blob/master/workshop.md) can help you get started. You can also jump straight to the final `step7` branch to have a reasonable starting place to build an app from. Note that it is not, however, meant to be a production ready app boilerplate.
 
-If you would like to go straight to the source, many of our application libraries can be found in the [quilt](https://github.com/Shopify/quilt) repo. These are all used internally and written against technologies we use for our own applications.
+If you would like to go straight to the source, many of our application libraries can be found in the [quilt](https://github.com/Shopify/quilt) repo. These are all used internally and written against technologies we use for our own applications. Some handy libraries for node apps you may want to look at are:
+* [@shopify/koa-shopify-auth](https://github.com/Shopify/quilt/tree/master/packages/koa-shopify-auth)
+* [@shopify/koa-shopify-graphql-proxy](https://github.com/Shopify/quilt/blob/master/packages/koa-shopify-graphql-proxy/README.md)
+* [@shopify/react-html](https://github.com/Shopify/quilt/blob/master/packages/react-html/README.md)
+
+Finally, as mentioned above we have some new things coming down the pipe soon. ❤️✨
 
 # Shopify Node App
 


### PR DESCRIPTION
This is a companion to the [deprecation PR on shopify-express](https://github.com/Shopify/shopify-express/pull/106).

As I mentioned there:
>This has been overdue for a while. It's no secret that we haven't been maintaining this package for a long time. We've released other packages as open source which more adhere to the tech-stack and model we use in node applications and removed this package from our official documentation already. In making this change I'd like to redirect as many people as possible from this repo to packages that we will actually be maintaining.

I've tried to include as much help as I can in the deprecation notice for those who might need it, and we won't be actually archiving this repo or anything so you can continue to use it if you want. To those who have contributed here, thank you so much. Of course, feel free to fork this and continue to develop it if you would like.

@markiiikram @tylerball, I know you had wanted to call out to our future plans in some way, is the current wording too vague, or just vague enough?

